### PR TITLE
Removed default parameter as it doesn't support ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var tick = require('next-tick');
  * @api public
  */
 
-module.exports = function loadIframe(options,fn,shouldMoveIframeToBody = false){
+module.exports = function loadIframe(options,fn,shouldMoveIframeToBody){
+  shouldMoveIframeToBody = shouldMoveIframeToBody || false
   if (!options) throw new Error('Cant load nothing...');
 
   // Allow for the simplest case, just passing a `src` string.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "load-iframe",
   "description": "Load an iframe by appending an iframe tag to the DOM.",
-  "version": "1.0.2-alpha.5",
+  "version": "1.0.2-alpha.6",
   "license": "MIT",
   "keywords": [
     "DOM",


### PR DESCRIPTION
This PR is to remove ES6 default parameter syntax as it was causing issue in circle-ci.
Linked PR :- https://github.com/segmentio/load-iframe/pull/6
Jira Ticket :- https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/371?modal=detail&selectedIssue=STRATCONN-1996&assignee=63617339fc0cc7a600b03c6b